### PR TITLE
 #47: ordering output by license

### DIFF
--- a/cmd/diligent/process.go
+++ b/cmd/diligent/process.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"os"
+	"sort"
 
 	"github.com/senseyeio/diligent"
 	"github.com/senseyeio/diligent/csv"
 	"github.com/senseyeio/diligent/stdout"
 )
+
+type toSortInterfacer func(deps []diligent.Dep) sort.Interface
 
 func getReporter() diligent.Reporter {
 	if csvFilePath != "" {
@@ -22,15 +25,18 @@ func run(args []string) {
 	if err != nil {
 		fatal(69, err.Error())
 	}
-	runDep(deper, getReporter(), filePath)
+
+	runDep(deper, getSort(sortByLicense), getReporter(), filePath)
 }
 
-func runDep(deper diligent.Deper, reporter diligent.Reporter, filePath string) {
+func runDep(deper diligent.Deper, sorter toSortInterfacer, reporter diligent.Reporter, filePath string) {
 	fileBytes := mustReadFile(filePath)
 	deps, warnings, err := deper.Dependencies(fileBytes)
 	if err != nil {
 		fatal(67, err.Error())
 	}
+
+	sort.Sort(sorter(deps))
 
 	for _, w := range warnings {
 		warning(w.Warning())
@@ -50,4 +56,21 @@ func runDep(deper diligent.Deper, reporter diligent.Reporter, filePath string) {
 	if len(warnings) > 0 {
 		os.Exit(64)
 	}
+}
+
+
+func toLicenseSorter(deps []diligent.Dep) sort.Interface {
+	return diligent.DepsByLicense(deps)
+}
+
+func toNameSorter (deps []diligent.Dep) sort.Interface {
+	return diligent.DepsByName(deps)
+}
+
+func getSort(useLicenseSorting bool) toSortInterfacer {
+	if useLicenseSorting {
+		return toLicenseSorter
+	}
+
+	return toNameSorter
 }

--- a/cmd/diligent/root.go
+++ b/cmd/diligent/root.go
@@ -9,6 +9,7 @@ var (
 	csvFilePath      string
 	licenseWhitelist []string
 	npmDevDeps       bool
+	sortByLicense    bool
 )
 
 var RootCmd = &cobra.Command{
@@ -29,6 +30,7 @@ func init() {
 func applyCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&npmDevDeps, "npm-dev-deps", "", false, "[NPM] Include developer dependencies")
 	cmd.Flags().StringVar(&csvFilePath, "csv", "", "Writes CSV to the provided file path")
+	cmd.Flags().BoolVarP(&sortByLicense, "license", "l", false, "sorts output by license")
 }
 
 func applyWhitelistFlag(cmd *cobra.Command) {

--- a/cmd/diligent/root.go
+++ b/cmd/diligent/root.go
@@ -30,7 +30,7 @@ func init() {
 func applyCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&npmDevDeps, "npm-dev-deps", "", false, "[NPM] Include developer dependencies")
 	cmd.Flags().StringVar(&csvFilePath, "csv", "", "Writes CSV to the provided file path")
-	cmd.Flags().BoolVarP(&sortByLicense, "license", "l", false, "sorts output by license")
+	cmd.Flags().BoolVarP(&sortByLicense, "license", "l", false, "Sorts output by license")
 }
 
 func applyWhitelistFlag(cmd *cobra.Command) {

--- a/dep.go
+++ b/dep.go
@@ -36,3 +36,15 @@ type Warnings []Warning
 func (d Warnings) Len() int           { return len(d) }
 func (d Warnings) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }
 func (d Warnings) Less(i, j int) bool { return d[i].Warning() < d[j].Warning() }
+
+type DepsByLicense []Dep
+
+func (d DepsByLicense) Len() int { return len(d) }
+func (d DepsByLicense) Swap(i, j int) { d[i], d[j] = d[j], d[i]}
+func (d DepsByLicense) Less(i, j int) bool {
+	if d[i].License.Name == d[j].License.Name {
+		return d[i].Name < d[j].Name
+	}
+
+	return d[i].License.Name < d[j].License.Name
+}


### PR DESCRIPTION
Closes #47 

Sorts by dependency name by default,  the `-l` flag can be used to sort by license.