### PR TITLE
Support output to std or file regardless of reporter

### DIFF
--- a/cmd/diligent/process.go
+++ b/cmd/diligent/process.go
@@ -9,6 +9,8 @@ import (
 	"github.com/senseyeio/diligent"
 	"github.com/senseyeio/diligent/csv"
 	"github.com/senseyeio/diligent/pretty"
+	"io"
+	"fmt"
 )
 
 type toSortInterfacer func(deps []diligent.Dep) sort.Interface
@@ -19,6 +21,23 @@ func getReporter() diligent.Reporter {
 	}
 
 	return pretty.NewReporter()
+}
+
+func withOutputWriter(todo func(w io.Writer) error) error {
+	var w io.Writer
+
+	if outputFilename != "" {
+		file, err := os.Create(outputFilename)
+		if err != nil {
+			return fmt.Errorf("unable to open file '%s' for writing. %v", outputFilename, err)
+		}
+		defer file.Close()
+		w = file
+	} else {
+		w = os.Stdout
+	}
+
+	return todo(w)
 }
 
 func getFiles(args []string) []string {
@@ -69,11 +88,16 @@ func run(args []string) {
 
 	sorter := getSort(sortByLicense)
 	sort.Sort(sorter(deps))
-
 	reporter := getReporter()
-	if err := reporter.Report(os.Stdout, deps); err != nil {
+
+	err := withOutputWriter(func(w io.Writer) error {
+		return reporter.Report(w, deps)
+	})
+
+	if err != nil {
 		fatal(65, err.Error())
 	}
+
 
 	if errs := validateDependencies(deps); len(errs) > 0 {
 		if len(errs) == 1 {

--- a/cmd/diligent/process.go
+++ b/cmd/diligent/process.go
@@ -14,8 +14,8 @@ import (
 type toSortInterfacer func(deps []diligent.Dep) sort.Interface
 
 func getReporter() diligent.Reporter {
-	if csvFilePath != "" {
-		return csv.NewReporter(csvFilePath)
+	if csvOutput {
+		return csv.NewReporter()
 	}
 
 	return pretty.NewReporter()
@@ -71,7 +71,7 @@ func run(args []string) {
 	sort.Sort(sorter(deps))
 
 	reporter := getReporter()
-	if err := reporter.Report(deps); err != nil {
+	if err := reporter.Report(os.Stdout, deps); err != nil {
 		fatal(65, err.Error())
 	}
 

--- a/cmd/diligent/root.go
+++ b/cmd/diligent/root.go
@@ -10,6 +10,7 @@ var (
 	npmDevDeps       bool
 	sortByLicense    bool
 	csvOutput bool
+	outputFilename string
 )
 
 var RootCmd = &cobra.Command{
@@ -31,6 +32,7 @@ func applyCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&npmDevDeps, "npm-dev-deps", "", false, "[NPM] Include developer dependencies")
 	cmd.Flags().BoolVarP(&csvOutput, "csv", "", false,  "Writes the output as comma separated values")
 	cmd.Flags().BoolVarP(&sortByLicense, "license", "l", false, "Sorts output by license")
+	cmd.Flags().StringVarP(&outputFilename, "out", "o", "", "Filename to which output should be written. By default or when blank stdout is used")
 }
 
 func applyWhitelistFlag(cmd *cobra.Command) {

--- a/cmd/diligent/root.go
+++ b/cmd/diligent/root.go
@@ -6,10 +6,10 @@ import (
 )
 
 var (
-	csvFilePath      string
 	licenseWhitelist []string
 	npmDevDeps       bool
 	sortByLicense    bool
+	csvOutput bool
 )
 
 var RootCmd = &cobra.Command{
@@ -29,7 +29,7 @@ func init() {
 
 func applyCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&npmDevDeps, "npm-dev-deps", "", false, "[NPM] Include developer dependencies")
-	cmd.Flags().StringVar(&csvFilePath, "csv", "", "Writes CSV to the provided file path")
+	cmd.Flags().BoolVarP(&csvOutput, "csv", "", false,  "Writes the output as comma separated values")
 	cmd.Flags().BoolVarP(&sortByLicense, "license", "l", false, "Sorts output by license")
 }
 

--- a/csv/reporter.go
+++ b/csv/reporter.go
@@ -2,8 +2,9 @@ package csv
 
 import (
 	encCSV "encoding/csv"
-	"github.com/senseyeio/diligent"
 	"io"
+
+	"github.com/senseyeio/diligent"
 )
 
 type csv struct {

--- a/csv/reporter.go
+++ b/csv/reporter.go
@@ -2,31 +2,23 @@ package csv
 
 import (
 	encCSV "encoding/csv"
-	"os"
-
 	"github.com/senseyeio/diligent"
+	"io"
 )
 
 type csv struct {
-	filePath string
 }
 
 // NewReporter returns a Reporter which outputs the discovered licenses to a CSV file
-func NewReporter(filePath string) diligent.Reporter {
-	return &csv{filePath}
+func NewReporter() diligent.Reporter {
+	return &csv{}
 }
 
 // Report outputs the dependencies and their licenses to a CSV file
-func (c *csv) Report(deps []diligent.Dep) error {
-	f, err := os.Create(c.filePath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
+func (c *csv) Report(w io.Writer, deps []diligent.Dep) error {
+	writer := encCSV.NewWriter(w)
 
-	writer := encCSV.NewWriter(f)
-
-	if err = writer.Write([]string{"Name", "License ID", "License Name", "License URL"}); err != nil {
+	if err := writer.Write([]string{"Name", "License ID", "License Name", "License URL"}); err != nil {
 		return err
 	}
 	for _, d := range deps {

--- a/pretty/reporter.go
+++ b/pretty/reporter.go
@@ -3,7 +3,6 @@ package pretty
 import (
 	"github.com/senseyeio/diligent"
 	"io"
-	"os"
 	"text/tabwriter"
 )
 
@@ -37,8 +36,8 @@ func writeStrings(w io.Writer, strings ...string) error {
 }
 
 // Report outputs the dependencies and their licenses in tabulated form to stdout
-func (c *pretty) Report(deps []diligent.Dep) error {
-	writer := tabwriter.NewWriter(os.Stdout, minColWidth, tabWidth, padding, padChar, flags)
+func (c *pretty) Report(w io.Writer, deps []diligent.Dep) error {
+	writer := tabwriter.NewWriter(w, minColWidth, tabWidth, padding, padChar, flags)
 
 	for _, d := range deps {
 		err := writeStrings(writer, d.Name, tab, d.License.Name, newline)

--- a/reporter.go
+++ b/reporter.go
@@ -1,6 +1,8 @@
 package diligent
 
+import "io"
+
 // Reporter takes an array of dependencies and outputs them to a certain medium
 type Reporter interface {
-	Report(deps []Dep) error
+	Report(w io.Writer, deps []Dep) error
 }


### PR DESCRIPTION
Closes #56 

- makes `--csv` a boolean switch, rather than taking a filename
- adds the `-o` flag, which takes a filename
- both the default and csv outputs may now be directed either to stdout (default), or a file using the `-o` flag